### PR TITLE
[WIP] bound-ff helper

### DIFF
--- a/addon/helpers/ff.js
+++ b/addon/helpers/ff.js
@@ -1,15 +1,32 @@
+import Ember from 'ember';
 import features from '../features';
 
-export function ff( value, options ) {
+var helpers = Ember.Handlebars.helpers;
+
+export function ff(featureKey, options) {
   var fnTrue = options.fn;
   var fnFalse = options.inverse;
+  var originalContext = this;
 
-  if( features.enabled(value) ) {
-    fnTrue(this);
+  if (options.contexts && options.contexts.length) {
+    originalContext = options.contexts[0];
   }
-  else {
-    fnFalse(this);
-  }
+
+  delete options.contexts;
+
+  options.fn = function (context, options) {
+    return fnTrue.call(originalContext, originalContext, options);
+  };
+
+  options.inverse = function (context, options) {
+    if (features.logFeatureFlagMissEnabled) {
+      features.logFeatureFlagMiss(featureKey);
+    }
+
+    return fnFalse.call(originalContext, originalContext, options);
+  };
+ 
+  return helpers.boundIf.call(window.Features, featureKey, options);
 }
 
 export default ff;

--- a/addon/tests/helpers/with-feature.js
+++ b/addon/tests/helpers/with-feature.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 
+var get = Ember.get;
+var set = Ember.set;
+
 export function withFeature( featureName ){
-  window.Features = window.Features || {};
-  window.Features[featureName] = true;
+  set(window, 'Features', get(window, 'Features') || {});
+  set(get(window, 'Features'), featureName, true);
 }
 
 Ember.Test.registerHelper( 'withFeature', function ( app, featureName ) {

--- a/addon/tests/helpers/without-feature.js
+++ b/addon/tests/helpers/without-feature.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+var get = Ember.get;
+var set = Ember.set;
+
+export function withoutFeature(featureName) {
+  set(window, 'Features', get(window, 'Features') || {});
+  set(get(window, 'Features'), featureName, false);
+}
+
+Ember.Test.registerHelper('withoutFeature', function (app, featureName) {
+  withoutFeature(featureName);
+});

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,6 +3,10 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
+window.Features = {
+  'acceptance-feature': true
+};
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 var App = Ember.Application.extend({

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  onLabel: 'ON',
+  offLabel: 'OFF'
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,9 +3,9 @@
 {{outlet}}
 
 {{#ff 'acceptance-feature'}}
-  <div class="acceptance-feature-on"></div>
+  <div class="acceptance-feature-on">{{onLabel}}</div>
 {{else}}
-  <div class="acceptance-feature-off"></div>
+  <div class="acceptance-feature-off">{{offLabel}}</div>
 {{/ff}}
 
 {{#ff 'off-feature'}}

--- a/tests/unit/helpers/ff-test.js
+++ b/tests/unit/helpers/ff-test.js
@@ -2,6 +2,7 @@ import {
   ff
   } from 'ember-feature-flags/helpers/ff';
 import { withFeature } from 'ember-feature-flags/tests/helpers/with-feature';
+import { withoutFeature } from 'ember-feature-flags/tests/helpers/without-feature';
 
 module('Feature Flag Helper', {
   teardown: function() {
@@ -46,3 +47,34 @@ test('it calls the true case when feature is off', function() {
   ff('some-feature', options);
 });
 
+test('it is bound to the Features object and updates when the feature is toggled on/off', function() {
+  expect(1);
+  var trueCount = 0;
+  var falseCount = 0;
+
+  function t() {
+    trueCount++;
+  }
+
+  function f() {
+    falseCount++;
+  }
+
+  var options = {
+    fn: t,
+    inverse: f
+  };
+
+  // Feature on
+  withFeature('some-feature');
+  ff('some-feature', options);
+
+  equal(trueCount, 1, 'true fn called once');
+  equal(falseCount, 0, 'false inverse fn not called');
+
+  // Feature off
+  withoutFeature('some-feature');
+
+  equal(trueCount, 1, 'true fn called once');
+  equal(falseCount, 1, 'false inverse fn called once');
+});


### PR DESCRIPTION
- [x] Initial demo of [how to piggyback](https://github.com/jayphelps/ember-feature-flags/blob/fe8322da9ca2e7a0cca3d31a14b75facdb41f174/addon/helpers/ff.js) on `boundIf` helper logic
- [ ] Convert tests to expect helper to now use a `SimpleHandlebarsView` (they don't pass because of this)
- [ ] Update README with examples
- [ ] Does this still work in Ember v1.8.0+ due the [view layer/helpers rewrite](https://github.com/emberjs/ember.js/commit/f839dcd89ad5ecc50d5403a06f507449380557b0) to use `Streams` instead of bufffers?