### PR TITLE
Ability for the flags to be specified in the containing app's config/environment.js

### DIFF
--- a/addon/features.js
+++ b/addon/features.js
@@ -1,10 +1,15 @@
-export default {
-  flags: {},
+import Ember from 'ember';
+
+export default Ember.Object.create({
+  flags: Ember.Object.create(),
   setup: function(flags) {
-    this.flags = flags;
+    this.flags = Ember.Object.create(flags);
   },
-  set: function(flag, enabled) {
-    this.flags[flag] = enabled;
+  enable: function(flag) {
+    this.flags.set(flag, true);
+  },
+  disable: function(flag) {
+    this.flags.set(flag, false);
   },
   enabled: function( feature ) {
     var isEnabled = this.featureIsEnabled(feature);
@@ -14,7 +19,7 @@ export default {
     return isEnabled;
   },
   featureIsEnabled: function( feature ) {
-    return !!(this.flags && this.flags[feature]);
+    return !!this.flags.get(feature);
   },
   logFeatureFlagMissEnabled: function() {
     return !!window.ENV && !!window.ENV.LOG_FEATURE_FLAG_MISS;
@@ -22,4 +27,4 @@ export default {
   logFeatureFlagMiss: function( feature ) {
     console.info('Feature flag off:', feature);
   }
-};
+});

--- a/addon/features.js
+++ b/addon/features.js
@@ -1,4 +1,11 @@
 export default {
+  flags: {},
+  setup: function(flags) {
+    this.flags = flags;
+  },
+  set: function(flag, enabled) {
+    this.flags[flag] = enabled;
+  },
   enabled: function( feature ) {
     var isEnabled = this.featureIsEnabled(feature);
     if( this.logFeatureFlagMissEnabled && !isEnabled ) {
@@ -7,13 +14,7 @@ export default {
     return isEnabled;
   },
   featureIsEnabled: function( feature ) {
-    if( window.Features === undefined ) {
-      return false;
-    }
-    if( window.Features[ feature ] === undefined ) {
-      return false;
-    }
-    return window.Features[feature ];
+    return !!(this.flags && this.flags[feature]);
   },
   logFeatureFlagMissEnabled: function() {
     return !!window.ENV && !!window.ENV.LOG_FEATURE_FLAG_MISS;

--- a/addon/initializers/ember-feature-flags.js
+++ b/addon/initializers/ember-feature-flags.js
@@ -5,7 +5,9 @@ import features from '../features';
 export default {
   name: 'ember-feature-flags',
   initialize: function( container, application ) {
-    features.setup(Ember.merge({}, application.FEATURES));
+    if (!Ember.isNone(application.FEATURES)) {
+      features.setup(application.FEATURES);
+    }
 
     container.optionsForType('features', { instantiate: false, singleton: true });
     application.inject('route', 'features', 'features:main');

--- a/addon/initializers/ember-feature-flags.js
+++ b/addon/initializers/ember-feature-flags.js
@@ -1,9 +1,12 @@
 import Ember from 'ember';
 import ifFeature from 'ember-feature-flags/helpers/if-feature';
+import features from '../features';
 
 export default {
   name: 'ember-feature-flags',
   initialize: function( container, application ) {
+    features.setup(Ember.merge({}, application.FEATURES));
+
     container.optionsForType('features', { instantiate: false, singleton: true });
     application.inject('route', 'features', 'features:main');
     application.inject('controller', 'features', 'features:main');

--- a/addon/tests/helpers/reset-feature-flags.js
+++ b/addon/tests/helpers/reset-feature-flags.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
+import features from 'ember-feature-flags/features';
 
 export function resetFeatureFlags(){
-  window.Features = {};
+  features.setup({});
 }
 
 Ember.Test.registerHelper( 'resetFeatureFlags', function () {

--- a/addon/tests/helpers/with-feature.js
+++ b/addon/tests/helpers/with-feature.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
+import features from 'ember-feature-flags/features';
 
 export function withFeature( featureName ){
-  window.Features = window.Features || {};
-  window.Features[featureName] = true;
+  features.set(featureName, true);
 }
 
 Ember.Test.registerHelper( 'withFeature', function ( app, featureName ) {

--- a/addon/tests/helpers/with-feature.js
+++ b/addon/tests/helpers/with-feature.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import features from 'ember-feature-flags/features';
 
 export function withFeature( featureName ){
-  features.set(featureName, true);
+  features.enable(featureName);
 }
 
 Ember.Test.registerHelper( 'withFeature', function ( app, featureName ) {

--- a/tests/acceptance/features-test.js
+++ b/tests/acceptance/features-test.js
@@ -32,6 +32,8 @@ test('visiting / with acceptance-feature on', function() {
   andThen(function() {
     equal(find('.acceptance-feature-on').length, 1, 'Acceptance feature on div should be in dom');
     equal(find('.acceptance-feature-off').length, 0, 'Acceptance feature off div should not be in dom');
+    equal(find('.bound-acceptance-feature-on').length, 1, 'Acceptance feature on div should be in dom');
+    equal(find('.bound-acceptance-feature-off').length, 0, 'Acceptance feature off div should not be in dom');
   });
 });
 

--- a/tests/acceptance/features-test.js
+++ b/tests/acceptance/features-test.js
@@ -1,16 +1,22 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
-import { withFeature} from 'ember-feature-flags/tests/helpers/with-feature';
+import {withFeature} from 'ember-feature-flags/tests/helpers/with-feature';
+import features from 'ember-feature-flags/features';
 
 var App;
 
 module('Acceptance: Features', {
   setup: function() {
+    features.setup({});
     App = startApp();
   },
   teardown: function() {
     Ember.run(App, 'destroy');
   }
+});
+
+test('features are defined in app config', function() {
+  ok(features.enabled('foo'), 'foo is allowed');
 });
 
 test('visiting / with acceptance-feature on', function() {

--- a/tests/acceptance/features-test.js
+++ b/tests/acceptance/features-test.js
@@ -16,7 +16,6 @@ module('Acceptance: Features', {
 });
 
 test('features are defined in app config', function() {
-  ok(features.enabled('feature-from-config'), 'feature-from-config is enabled automatically');
   visit('/');
 
   andThen(function() {
@@ -32,8 +31,6 @@ test('visiting / with acceptance-feature on', function() {
   andThen(function() {
     equal(find('.acceptance-feature-on').length, 1, 'Acceptance feature on div should be in dom');
     equal(find('.acceptance-feature-off').length, 0, 'Acceptance feature off div should not be in dom');
-    equal(find('.bound-acceptance-feature-on').length, 1, 'Acceptance feature on div should be in dom');
-    equal(find('.bound-acceptance-feature-off').length, 0, 'Acceptance feature off div should not be in dom');
   });
 });
 

--- a/tests/acceptance/features-test.js
+++ b/tests/acceptance/features-test.js
@@ -16,7 +16,13 @@ module('Acceptance: Features', {
 });
 
 test('features are defined in app config', function() {
-  ok(features.enabled('foo'), 'foo is allowed');
+  ok(features.enabled('feature-from-config'), 'feature-from-config is enabled automatically');
+  visit('/');
+
+  andThen(function() {
+    equal(find('.feature-from-config-on').length, 1, '.feature-from-config-on should be in dom');
+    equal(find('.feature-from-config-off').length, 0, '.feature-from-config-off should not be in dom');
+  });
 });
 
 test('visiting / with acceptance-feature on', function() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -8,6 +8,12 @@
   <div class="acceptance-feature-off"></div>
 {{/if-feature}}
 
+{{#if-feature 'feature-from-config'}}
+  <div class="feature-from-config-on"></div>
+{{else}}
+  <div class="feature-from-config-off"></div>
+{{/if-feature}}
+
 {{#if-feature 'off-feature'}}
   <div class="off-feature-on"></div>
 {{/if-feature}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -17,9 +17,3 @@
 {{#if-feature 'off-feature'}}
   <div class="off-feature-on"></div>
 {{/if-feature}}
-
-{{#if features.flags.acceptance-feature}}
-  <div class="bound-acceptance-feature-on"></div>
-{{else}}
-  <div class="bound-acceptance-feature-off"></div>
-{{/if}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -17,3 +17,9 @@
 {{#if-feature 'off-feature'}}
   <div class="off-feature-on"></div>
 {{/if-feature}}
+
+{{#if features.flags.acceptance-feature}}
+  <div class="bound-acceptance-feature-on"></div>
+{{else}}
+  <div class="bound-acceptance-feature-off"></div>
+{{/if}}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,7 +17,7 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
       FEATURES: {
-        foo: true
+        'feature-from-config': true
       }
     }
   };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,9 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      FEATURES: {
+        foo: true
+      }
     }
   };
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/test-support.css">
     <style>
       #ember-testing-container {
-        position: absolute;
+        position: fixed;
         background: white;
         bottom: 0;
         right: 0;
@@ -24,6 +24,9 @@
         overflow: auto;
         z-index: 9999;
         border: 1px solid #ccc;
+      }
+      #qunit {
+        margin-bottom: 400px;
       }
       #ember-testing {
         zoom: 50%;

--- a/tests/unit/features-test.js
+++ b/tests/unit/features-test.js
@@ -1,6 +1,6 @@
 import {
   test
-  } from 'ember-qunit';
+} from 'ember-qunit';
 import features from 'ember-feature-flags/features';
 
 module('features:main');
@@ -27,19 +27,19 @@ test('logFeatureFlagMissEnabled', function() {
 });
 
 test('featureIsEnabled', function() {
-  var origFeatures = window.Features;
+  var origFeatures = features.flags;
 
-  window.Features = undefined;
+  features.setup(undefined);
   equal(features.featureIsEnabled('some-feature'), false, 'Feature is false if Features is undefined');
 
-  window.Features = {};
+  features.setup({});
   equal(features.featureIsEnabled('some-feature'), false, 'Feature is false if Feature on Features is undefined');
 
-  window.Features = {"some-feature": true};
+  features.setup({"some-feature": true});
   equal(features.featureIsEnabled('some-feature'), true, 'Feature is true if feature is set to true');
 
-  window.Features = {"some-feature": false};
+  features.setup({"some-feature": false});
   equal(features.featureIsEnabled('some-feature'), false, 'Feature is false if feature is set to false');
 
-  window.Features = origFeatures;
+  features.setup(origFeatures);
 });

--- a/tests/unit/helpers/if-feature-test.js
+++ b/tests/unit/helpers/if-feature-test.js
@@ -1,11 +1,12 @@
 import {
   ifFeature
-  } from 'ember-feature-flags/helpers/if-feature';
+} from 'ember-feature-flags/helpers/if-feature';
 import { withFeature } from 'ember-feature-flags/tests/helpers/with-feature';
+import features from 'ember-feature-flags/features';
 
 module('Feature Flag Helper', {
   teardown: function() {
-    window.Features = {};
+    features.setup({});
   }
 });
 

--- a/tests/unit/initializers/ember-feature-flags-test.js
+++ b/tests/unit/initializers/ember-feature-flags-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import init from 'ember-feature-flags/initializers/ember-feature-flags';
+import features from 'ember-feature-flags/features';
 
 var container, application;
 
@@ -7,7 +8,11 @@ module('EmberFeatureFlagsInitializer', {
   setup: function() {
     Ember.run(function() {
       container = new Ember.Container();
-      application = Ember.Application.create();
+      application = Ember.Application.create({
+        FEATURES: {
+          'feature-from-config': true
+        }
+      });
       application.deferReadiness();
     });
   }
@@ -15,8 +20,7 @@ module('EmberFeatureFlagsInitializer', {
 
 test('it works', function() {
   init.initialize(container, application);
-  // you would normally confirm the results of the initializer here
-  ok(true);
+  ok(features.enabled('feature-from-config'));
 });
 
 test('it injects into all types', function() {


### PR DESCRIPTION
Thanks for this, I've just made some changes that I think are valuable:

- Flags can be specified in `config/environment.js` (under `APP.FEATURES`), and are automatically provided to the addon in the intiializer
- Avoids storing the flags on the `window` object, instead they're contained within the `ember-feature-flags/features` module.

This doesn't update the documentation, although I'm happy to do that if you agree with the PR. One other thought that occurred to me is that if you rename `addon/features.js` to `addon/index.js` then it can be imported using `import features from 'ember-feature-flags';`. Just a thought :)

Cheers!