### PR TITLE
Added withoutFeature to turn off features

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ test( "links go to the new homepage", function () {
 });
 ```
 
+#### `withoutFeature`
+
+Turns off a feature for the test in which it is called.
+To use, import into your test-helper.js: `import 'ember-feature-flags/tests/helpers/without-feature'` and add to your 
+test `.jshintrc`, it will now be available in all of your tests.
+
+Example:
+
+```js
+import 'ember-feature-flags/tests/helpers/without-feature';
+
+test( "links do NOT go to the new homepage", function () {
+  withoutFeature( 'new-homepage' );
+
+  visit('/');
+  click('a.home');
+  andThen(function(){
+    notEqual(currentRoute(), 'new.homepage', 'Should not be on the new homepage');
+  });
+});
+```
+
 ### Development
 
 #### Installation

--- a/addon/tests/helpers/without-feature.js
+++ b/addon/tests/helpers/without-feature.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export function withoutFeature ( app, featureName ) {
+  var featuresService = app.__container__.lookup('features:-main');
+  featuresService.disable(featureName);
+}
+
+Ember.Test.registerHelper( 'withoutFeature', withoutFeature );

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -22,7 +22,8 @@
     "currentURL",
     "currentPath",
     "currentRouteName",
-    "withFeature"
+    "withFeature",
+    "withoutFeature"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/features-test.js
+++ b/tests/acceptance/features-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import {module, test} from 'qunit';
 import startApp from '../helpers/start-app';
 import {withFeature} from 'ember-feature-flags/tests/helpers/with-feature';
+import {withoutFeature} from 'ember-feature-flags/tests/helpers/without-feature';
 import config from "dummy/config/environment";
 
 var App, oldDeprecate, oldFeatureFlags;
@@ -77,5 +78,24 @@ test('visiting / with no features set', function(assert) {
   andThen(function() {
     assert.equal(find('.acceptance-feature-on').length, 0, 'Acceptance feature on div should not be in dom');
     assert.equal(find('.acceptance-feature-off').length, 1, 'Acceptance feature off div should be in dom');
+  });
+});
+
+test('using withFeature and withoutFeature to toggle acceptance-feature on/off', function(assert) {
+  App = startApp();
+  withFeature(App, 'acceptance-feature');
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('.acceptance-feature-on').length, 1, 'Acceptance feature on div should be in dom');
+    assert.equal(find('.acceptance-feature-off').length, 0, 'Acceptance feature off div should not be in dom');
+
+    // Now turn the feature off and revist the page
+    withoutFeature(App, 'acceptance-feature');
+      visit('/');
+      andThen(function(){
+        assert.equal(find('.acceptance-feature-on').length, 0, 'Acceptance feature on div should not be in dom');
+        assert.equal(find('.acceptance-feature-off').length, 1, 'Acceptance feature off div should be in dom');
+      });
   });
 });


### PR DESCRIPTION
Thought it might be nice to have a “withoutFeature” test helper that does just the opposite of “withFeature.” This is one of my first PRs for ember code, so let me know if I did anything weird or if you think this is unnecessary.

Cheers!