### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An ember-cli addon to provide feature flags.
 ### Installation
 
 ```
-ember install:addon ember-feature-flags
+ember install ember-feature-flags
 ```
 
 ### Usage


### PR DESCRIPTION
In ember-cli 0.2.3 ember install:addon command was removed.  Use ember install ember-feature-flags instead: http://discuss.emberjs.com/t/in-ember-cli-0-2-3-ember-install-addon-command-was-removed/7757