### PR TITLE
Changed 'repository' property of package.json to object format

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/kategengler/ember-feature-flags",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kategengler/ember-feature-flags"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
I noticed that there was no link to the github page on the [npmjs.org page](https://www.npmjs.com/package/ember-feature-flags) for this project. [Looking at the docs](https://docs.npmjs.com/files/package.json#repository), I think the issue is that if the value is a string it's expecting shorthand form, not as a fully qualified URI. So alternatively, the `repository` field could be changed to `"kategengler/ember-feature-flags"`, but the vast majority of other ember-cli packages seem to use the object form.