### PR TITLE
Fix Ember 2.1 deprecation keeping retrocompatibility

### DIFF
--- a/app/initializers/ember-feature-flags.js
+++ b/app/initializers/ember-feature-flags.js
@@ -1,8 +1,10 @@
 import config from '../config/environment';
 import Features from '../features/-main';
 
-export function initialize( registry, application ) {
+export function initialize() {
+  var application = arguments[1] || arguments[0];
   var serviceName = config.featureFlagsService || 'features';
+
   application.register('features:-main', Features);
   application.inject('route', serviceName, 'features:-main');
   application.inject('controller', serviceName, 'features:-main');


### PR DESCRIPTION
On Ember 2.1, I was seeing this error:

```
The `initialize` method for Application initializer 'ember-feature-flags' should take only one argument - `App`, an instance of an `Application`.
```

This PR should fix the deprecation, while maintaining retrocompatibility with previous versions. (cfr. http://emberjs.com/deprecations/v2.x/#toc_initializer-arity)