### PR TITLE
Add docs for stubbing features service in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ test( "links go to the new homepage", function () {
 });
 ```
 
+### Integration Tests
+
+If you use `this.features.isEnabled()` in components under integration test, you will need to inject a stub service in your tests. Using ember-qunit 0.4.16 or later, here's how to do this:
+
+```js
+let featuresService = Ember.Service.extend({
+  isEnabled() {
+    return false;
+  }
+});
+
+moduleForComponent('my-component', 'Integration | Component | my component', {
+  integration: true,
+  beforeEach() {
+    this.register('service:features', featuresService);
+    this.container.injection('component', 'features', 'service:features');
+  }
+});
+```
+
 ### Development
 
 #### Installation

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ test( "links go to the new homepage", function () {
 If you use `this.features.isEnabled()` in components under integration test, you will need to inject a stub service in your tests. Using ember-qunit 0.4.16 or later, here's how to do this:
 
 ```js
+const { getOwner } = Ember;
+
 let featuresService = Ember.Service.extend({
   isEnabled() {
     return false;
@@ -151,10 +153,12 @@ moduleForComponent('my-component', 'Integration | Component | my component', {
   integration: true,
   beforeEach() {
     this.register('service:features', featuresService);
-    this.container.injection('component', 'features', 'service:features');
+    getOwner(this).inject('component', 'features', 'service:features');
   }
 });
 ```
+
+Note: for Ember before 2.3.0, you'll need to use [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill).
 
 ### Development
 


### PR DESCRIPTION
Integration tests don't have the features service injected by default, but we can set up a stub and inject it ourselves. This allows toggling features on and off within tests. This commit adds a doc section to show how to do it.

Fixes #35.

You can see an example of this approach on [this branch of my trivial name-editor component](https://github.com/alisdair/name-editor/commits/feature-flags) if you want to see it in action.

Thanks for building this add-on, it's super useful!