### PR TITLE
Automatically inject into adapters

### DIFF
--- a/app/initializers/ember-feature-flags.js
+++ b/app/initializers/ember-feature-flags.js
@@ -10,6 +10,7 @@ export function initialize() {
   application.inject('route', serviceName, serviceLookupName);
   application.inject('controller', serviceName, serviceLookupName);
   application.inject('component', serviceName, serviceLookupName);
+  application.inject('adapter', serviceName, serviceLookupName);
   application.inject(serviceLookupName, 'application', 'application:main');
 }
 

--- a/tests/unit/initializers/ember-feature-flags-test.js
+++ b/tests/unit/initializers/ember-feature-flags-test.js
@@ -32,7 +32,7 @@ test('service has application injected', function(assert) {
   assert.ok(service.application, 'service has application');
 });
 
-['route', 'controller', 'component'].forEach(function(type) {
+['route', 'controller', 'component', 'adapter'].forEach(function(type) {
   test(`${type} has service injected`, function(assert) {
     initialize(registry, application);
     application.register(`${type}:main`, Ember.Object.extend());
@@ -41,7 +41,7 @@ test('service has application injected', function(assert) {
   });
 });
 
-['route', 'controller', 'component'].forEach(function(type) {
+['route', 'controller', 'component', 'adapter'].forEach(function(type) {
   test(`${type} has service injected with custom name`, function(assert) {
     config.featureFlagsService = 'wackyWhoop';
     initialize(registry, application);


### PR DESCRIPTION
Thanks for the great addon! I'm sure there was a conscious to decision made to limit automatic injection to routes/controllers/components, given that not everyone uses Ember Data. That said, I noticed #42 and I'd also like some similar functionality within adapters for [travis-web](https://github.com/travis-ci/travis-web). 

Unfortunately, I'm not sure how to selectively accommodate the presence of Ember Data, which probably renders this not particularly useful. Feel free to close this, though it might be good in that case to document how to modify the initializer to achieve this (and something similar for services).

