### PR TITLE
Fix syntax highlighting hint for template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default Ember.Controller.extend({
 
 Check whether a feature is enabled in a template:
 
-```html
+```hbs
 {{#if features.newHomepage}}
   {{link-to "new.homepage"}}
 {{else}}


### PR DESCRIPTION
This swaps the syntax highlighting hint from `html` to `hbs` for the template example in the README to improve the highlighting.