### PR TITLE
Deprecate feature flags service option

### DIFF
--- a/app/initializers/ember-feature-flags.js
+++ b/app/initializers/ember-feature-flags.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import config from '../config/environment';
 import Features from '../services/features';
+
+const INJECTION_FACTORIES_DEPRECATION_MESSAGE = '[ember-feature-flags] Future versions of ember-feature-flags will no longer inject the service automatically. Instead, you should explicitly inject it into your Route, Controller or Component with `Ember.inject.service`.';
 
 export function initialize() {
   let application = arguments[1] || arguments[0];
@@ -11,6 +14,11 @@ export function initialize() {
   application.inject('controller', serviceName, serviceLookupName);
   application.inject('component', serviceName, serviceLookupName);
   application.inject(serviceLookupName, 'application', 'application:main');
+
+  Ember.deprecate(INJECTION_FACTORIES_DEPRECATION_MESSAGE, false, {
+    id: 'ember-feature-flags.deprecate-injection-factories',
+    until: '4.0.0'
+  });
 }
 
 export default {


### PR DESCRIPTION
This is a follow up to https://github.com/kategengler/ember-feature-flags/pull/60#pullrequestreview-88929401

@kategengler I've added deprecation message only in cases when custom `featureFlagsService` option provided that is different from default value.

I'm not sure if issuing deprecation without a condition would be better option.