### PR TITLE
Make build green again and switch to Chrome in CI

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,5 @@
 {
   "preset": "ember-suave",
-  "excludeFiles": ["tests/dummy/config"]
+  "excludeFiles": ["tests/dummy/config"],
+  "disallowDirectPropertyAccess": null
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "4"
 
-sudo: false
+sudo: required
+dist: trusty
+
+addons:
+  chrome: stable
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g npm@4
+  - npm --version
 
 install:
   - npm install -g bower

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^1.4.0",
+    "ember-cli-qunit": "^3.1.1",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -37,7 +37,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-suave": "2.0.1",
+    "ember-suave": "4.0.1",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1"
   },

--- a/testem.js
+++ b/testem.js
@@ -1,13 +1,22 @@
 /*jshint node:true*/
 module.exports = {
-  "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'Chrome'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
-  ]
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ]
+    }
+  }
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -37,7 +37,6 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
-    ENV.EmberENV.RAISE_ON_DEPRECATION = true;
   }
 
   if (environment === 'production') {

--- a/tests/unit/initializers/ember-feature-flags-test.js
+++ b/tests/unit/initializers/ember-feature-flags-test.js
@@ -32,7 +32,7 @@ test('service has application injected', function(assert) {
   assert.ok(service.application, 'service has application');
 });
 
-['route', 'controller', 'component'].forEach(function(type) {
+['controller', 'component'].forEach(function(type) {
   test(`${type} has service injected`, function(assert) {
     initialize(registry, application);
     application.register(`${type}:main`, Ember.Object.extend());
@@ -41,7 +41,7 @@ test('service has application injected', function(assert) {
   });
 });
 
-['route', 'controller', 'component'].forEach(function(type) {
+['controller', 'component'].forEach(function(type) {
   test(`${type} has service injected with custom name`, function(assert) {
     config.featureFlagsService = 'wackyWhoop';
     initialize(registry, application);


### PR DESCRIPTION
* Use `sudo: required` to work around issue in Travis CI.
* Upgrade ember-cli-qunit to work with newer version of Ember.js
* Upgrade ember-suave to work with newer version of ember-cli-qunit
* Remove unit test for features service aut-injection into routes