### PR TITLE
✨ add computed-property macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ ember install ember-feature-flags
 
 ### Usage
 
+#### Computed-Property Macro
+
+This addon provides a computed-property macro that you can use to add properties that toggle
+whenever feature-flags do:
+```js
+import Controller from '@ember/controller';
+import { macro as featureFlag } from 'ember-feature-flags';
+export default Controller.extend({
+  hasNewBilling: featureFlag('new-billing-plans')
+});
+```
+
+The argument to the macro can be camelCase, snake_case, or kebab-case.
+
+#### Service
+
 This addon provides a service named `features` available for injection into your routes, controllers, components, etc.
 
 For example you may check if a feature is enabled:
@@ -33,7 +49,8 @@ export default Controller.extend({
 });
 ```
 
-Features are also available as properties of `features`. They are camelized.
+Features are also available as properties of `features`. These properties are camelized,
+regardless of how the feature-flag is spelled.
 
 ```js
 import Controller from '@ember/controller';
@@ -71,7 +88,9 @@ export default Component.extend({
 });
 ```
 
-Alternatively you can use a template helper named `feature-flag`:
+#### Helper
+
+Alternatively, you can use a template helper named `feature-flag`:
 
 ```hbs
 // templates/components/homepage-link.hbs
@@ -81,6 +100,8 @@ Alternatively you can use a template helper named `feature-flag`:
   {{link-to "old.homepage"}}
 {{/if}}
 ``` 
+
+The helper, like the computed-property macro, works with camelCase, snake_case, or kebab-case.
 
 Features can be toggled at runtime, and are bound:
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,3 @@
+import macro from './macros/feature-flag';
+
+export { macro }

--- a/addon/macros/feature-flag.js
+++ b/addon/macros/feature-flag.js
@@ -1,0 +1,21 @@
+import { camelize } from '@ember/string';
+import { computed, get, set } from '@ember/object';
+import { getOwner } from '@ember/application';
+
+const featuresServiceProperty = `_features_${+(new Date())}`
+
+export default function featureFlagMacro(flag) {
+  const flagPath = `${featuresServiceProperty}.${camelize(flag)}`;
+
+  return computed(flagPath, function() {
+    ensureFeaturesInjection(this);
+    return get(this, flagPath);
+  });
+}
+
+function ensureFeaturesInjection(object) {
+  if (!get(object, featuresServiceProperty)) {
+    const features = getOwner(object).lookup('service:features')
+    set(object, featuresServiceProperty, features)
+  }
+}

--- a/tests/integration/macros/feature-flag-test.js
+++ b/tests/integration/macros/feature-flag-test.js
@@ -1,0 +1,31 @@
+import { moduleFor, test } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import { macro as featureFlag } from 'ember-feature-flags';
+import { run } from '@ember/runloop';
+
+const Thing = EmberObject.extend({
+  someFeatureIsEnabled: featureFlag('some-feature')
+});
+
+moduleFor('model:thing', 'computed-property-macro:feature-flag', {
+  integration: true,
+
+  beforeEach () {
+    this.register('model:thing', Thing);
+    this.inject.service('features');
+  }
+});
+
+test('it returns true when the feature flag is enabled', function(assert) {
+  const thing = this.subject();
+  assert.equal(thing.get('someFeatureIsEnabled'), false, 'initial');
+  run(this.features, 'enable', 'some-feature');
+  assert.equal(thing.get('someFeatureIsEnabled'), true, 'recompute');
+});
+
+test('it observes changes to alternate spellings', function(assert) {
+  const thing = this.subject();
+  assert.equal(thing.get('someFeatureIsEnabled'), false, 'initial');
+  run(this.features, 'enable', 'someFeature');
+  assert.equal(thing.get('someFeatureIsEnabled'), true, 'recompute');
+});


### PR DESCRIPTION
Feature flags are available as properties on `service:features`, which makes them easy to bind to:

```js
features: service(),

plans: computed('features.newPlans', function() {
  return this.get('features.newPlans') ? newPlans() : oldPlans()
})
```

Unfortunately, those properties are always camelCased, even if your project uses a different convention. `this.get('features.new-plans')` will work because of `service:features#unknownProperty`. But `computed('features.new-plans', …)` will not because Ember's property-observer system doesn't obey `unknownProperty`.

Instead, you can use the computed-property macro to create properties based off feature-flags using whatever flag convention you like:

```js
hasNewPlans: featureFlag('new-plans'),

plans: computed('hasNewPlans', function() {
  return this.get('hasNewPlans') ? newPlans() : oldPlans()
})
```