### PR TITLE
Replace computed.volatile with native getter

### DIFF
--- a/addon/services/features.js
+++ b/addon/services/features.js
@@ -74,6 +74,13 @@ const FeaturesService = Service.extend({
   }
 });
 
+// Use a native getter instead of a `volatile` computed property since those
+// were deprecated as of Ember 3.9. The Object.defineProperty approach (from
+// https://github.com/emberjs/ember.js/issues/17709#issuecomment-469941364 is
+// used because defining native getters directly on EmberObject-based classes
+// is only supported from Ember 3.9 on (https://github.com/emberjs/ember.js/pull/17710)
+// and this preserves compatiblity until this addon drops support for older
+// Ember versions.
 Object.defineProperty(FeaturesService.prototype, 'flags', {
   get() {
     return Object.keys(this._flags);

--- a/addon/services/features.js
+++ b/addon/services/features.js
@@ -1,9 +1,8 @@
 /*eslint-disable no-extra-boolean-cast, no-console */
 import Service from '@ember/service';
 import { camelize } from '@ember/string';
-import { computed } from '@ember/object';
 
-export default Service.extend({
+const FeaturesService = Service.extend({
 
   init() {
     this._super(...arguments);
@@ -47,10 +46,6 @@ export default Service.extend({
     return isEnabled;
   },
 
-  flags: computed(function () {
-    return Object.keys(this._flags);
-  }).volatile(),
-
   _resetFlags() {
     this._flags = Object.create(null);
   },
@@ -77,5 +72,12 @@ export default Service.extend({
   unknownProperty(key) {
     return this.isEnabled(key);
   }
-
 });
+
+Object.defineProperty(FeaturesService.prototype, 'flags', {
+  get() {
+    return Object.keys(this._flags);
+  }
+});
+
+export default FeaturesService;


### PR DESCRIPTION
Fixes #82. This uses the `defineProperty` approach from https://github.com/emberjs/ember.js/issues/17709#issuecomment-469941364 since it should work with all versions of Ember supported by the addon. (The change in https://github.com/emberjs/ember.js/pull/17710 that would allow nicer semantics for this is only available starting in Ember 3.9.)