### PR TITLE
refactor(observers): replace observer usage / simplify helper

### DIFF
--- a/addon/helpers/feature-flag.js
+++ b/addon/helpers/feature-flag.js
@@ -1,28 +1,10 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
-import { camelize } from '@ember/string';
 
 export default Helper.extend({
   features: service(),
 
   compute([flag]) {
-    if (this._observedFlag) {
-      this.get('features').removeObserver(this._observedFlag, this, 'recompute');
-    }
-
-    this.set('_observedFlag', camelize(flag));
-    this.get('features').addObserver(this._observedFlag, this, 'recompute');
-
-    return this.get('features').isEnabled(flag);
+    return this.features.get(flag)
   },
-
-  _observedFlag: null,
-
-  willDestroy () {
-    this._super(...arguments);
-
-    if (this._observedFlag) {
-      this.get('features').removeObserver(this._observedFlag, this, 'recompute');
-    }
-  }
 });

--- a/addon/helpers/feature-flag.js
+++ b/addon/helpers/feature-flag.js
@@ -5,6 +5,6 @@ export default Helper.extend({
   features: service(),
 
   compute([flag]) {
-    return this.features.get(flag)
+    return this.get('features').get(flag)
   },
 });

--- a/tests/integration/helpers/feature-flag-test.js
+++ b/tests/integration/helpers/feature-flag-test.js
@@ -71,4 +71,27 @@ module('Integration | Helper | feature-flag', function(hooks) {
 
     assert.equal(this.element.textContent.trim(), 'Some text');
   });
+
+  test('it recomputes when flag reference changes', async function(assert) {
+    this.features.setup({
+      someFeatureA: false,
+      someFeatureB: true,
+    });
+
+    this.set('currentFlag', 'someFeatureA');
+
+    await render(hbs`
+      {{#if (feature-flag this.currentFlag)}}
+        Some text
+      {{else}}
+        Some other text
+      {{/if}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'Some other text');
+
+    this.set('currentFlag', 'someFeatureB');
+
+    assert.equal(this.element.textContent.trim(), 'Some text');
+  });
 });


### PR DESCRIPTION
The observer usage in the `feature-flag` helper seems to not really be needed.

If a flag changes on the features service, it will update the child references down the line

~~All tests still passing~~

EDIT: nevermind, it fails on older ember versions, and it wouldn't normalize the flag or log the feature flag misses anyway.