### PR TITLE
Introduce GitHub Actions config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          cache: "yarn"
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint
+        run: yarn lint
+
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 8.x
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run Tests
+        run: yarn test
+
+  compat:
+    name: other version tests
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - ember-lts-3.4
+          - ember-lts-3.8
+          # These are the 3.x LTS's we should *add*
+          # - ember-lts-3.24
+          # - ember-lts-3.28
+          # currently failing b/c they're on Ember v4
+          # - ember-release
+          # - ember-beta
+          # - ember-canary
+
+    continue-on-error: ${{ matrix.scenario == 'ember-canary' }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 8.x
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run Tests
+        run: node_modules/.bin/ember try:one ${{ matrix.scenario }} --skip-cleanup


### PR DESCRIPTION
Travis is dead, so this needs to happen anyway. Key things to notice:

- The Travis config remains because this version of the GHA config does not have the publishing step set up; that still needs to be moved over.

- The Travis-powered CI is currently failing, and also does not run against *any* recent version of Ember, and this intentionally does not update what is tested; a future change should do that.