### PR TITLE
CI: fix linting and add missing scenarios to compat tests 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,10 +55,11 @@ jobs:
         scenario:
           - ember-lts-3.4
           - ember-lts-3.8
-          # These are the 3.x LTS's we should *add*
-          # - ember-lts-3.24
-          # - ember-lts-3.28
-          # currently failing b/c they're on Ember v4
+          - ember-lts-3.12
+          - ember-lts-3.16
+          - ember-lts-3.20
+          - ember-lts-3.24
+          - ember-lts-3.28
           # - ember-release
           # - ember-beta
           # - ember-canary

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-lts-3.24
-          - ember-lts-3.28
+          # - ember-lts-3.28
           # - ember-release
           # - ember-beta
           # - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -23,6 +23,46 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
+    "lint": "yarn lint:js && yarn lint:hbs",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",


### PR DESCRIPTION
@chriskrycho @kategengler this is same as #121 but disables 3.28 LTS scenario for now.

my thought process we can get this in "as is" to make CI green and in follow up PRs update addon setup to pass *all* the scenarios as well as latest canary.

Closes #121.